### PR TITLE
Add sample HAR/DAR files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,4 +76,7 @@ _site/
 # DAR and HAR specific
 *.dar
 *.har
+# Allow example files in samples/
+!samples/*.dar
+!samples/*.har
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ python tools/har_to_dar_converter.py input.har output.dar
 
 ### Examples
 
-Check the `samples/` directory for example DAR files that demonstrate the extended capabilities of this format. Sample files include real-world use cases to help you get started quickly.
+Check the `samples/` directory for example `.har` and `.dar` files. These samples let you try the converter and inspect DAR output immediately. To view them from the command line:
+
+```bash
+less samples/example.har
+jq '.' samples/example.dar
+```
 
 ## **DAR Schema Specification**
 

--- a/samples/example.dar
+++ b/samples/example.dar
@@ -1,0 +1,22 @@
+{
+  "log": {
+    "version": "1.4",
+    "creator": {
+      "name": "DAR Converter",
+      "version": "1.0"
+    },
+    "renders": [
+      {
+        "url": "https://example.com",
+        "status": "200",
+        "content": "<html>...</html>",
+        "time": "2024-09-05T12:00:00Z"
+      }
+    ],
+    "result": {
+      "summary": "Crawl completed successfully"
+    },
+    "entries": []
+  }
+}
+

--- a/samples/example.har
+++ b/samples/example.har
@@ -1,0 +1,11 @@
+{
+  "log": {
+    "version": "1.2",
+    "creator": {
+      "name": "Sample",
+      "version": "1.0"
+    },
+    "entries": []
+  }
+}
+


### PR DESCRIPTION
## Summary
- allow HAR/DAR examples by updating `.gitignore`
- provide minimal `examples.har` and `example.dar` in new `samples/` folder
- update README with quick commands for inspecting sample files

## Testing
- `PYTHONPATH=. python tests/test_converter.py`
- `PYTHONPATH=. python tests/test_dar_parser.py`


------
https://chatgpt.com/codex/tasks/task_e_6840809bdfe483338234d24c28361f79