### PR TITLE
Add argparse CLIs for parser and validator

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -85,15 +85,15 @@ Once you have your DAR file, you can use the `dar_parser.py` tool to read and an
 
 ### Step 1: Parse the DAR File
 
-Run the `dar_parser.py` script to parse the DAR file and extract key information.
+Run the `dar_parser.py` script with the `--summary` flag to parse the DAR file and display a summary.
 
 ```bash
-python tools/dar_parser.py
+python tools/dar_parser.py --summary output.dar
 ```
 
 ### Step 2: View the Parsed Data
 
-The script will prompt you for the path to your DAR file and output a summary, including:
+The script will output a summary that includes:
 - Number of renders captured.
 - Summary of scraping results.
 - Number of HTTP request entries.
@@ -108,6 +108,14 @@ parser = DARParser('output.dar')
 
 # Print a detailed summary of the DAR file
 parser.print_dar_summary()
+```
+
+### Step 3: Validate the DAR File
+
+Use the validator script to ensure the file conforms to the DAR schema:
+
+```bash
+python tools/validators/dar_validator.py --validate output.dar
 ```
 
 ## Integrating DAR in Your Scraping Workflow

--- a/docs/usage-examples.md
+++ b/docs/usage-examples.md
@@ -46,7 +46,7 @@ Parsing DAR files is straightforward using the `dar_parser.py` script. This pars
 2. **Parse the DAR file using the `dar_parser.py` script**:
 
     ```bash
-    python tools/dar_parser.py
+    python tools/dar_parser.py --summary sample_output.dar
     ```
 
 3. **View the parsed data**: The script will output a summary of the DAR file, including the number of renders, summary of results, and number of request entries.
@@ -120,6 +120,14 @@ convert_har_to_dar('session.har', 'session.dar')
 # Parse the DAR file and analyze results
 parser = DARParser('session.dar')
 parser.print_dar_summary()
+```
+
+## Validating a DAR File
+
+Before using a DAR file in production, you can validate it against the schema:
+
+```bash
+python tools/validators/dar_validator.py --validate session.dar
 ```
 
 ## Error Handling and Metrics

--- a/tools/dar_parser.py
+++ b/tools/dar_parser.py
@@ -8,6 +8,7 @@ with additional objects such as 'renders' and 'result'.
 """
 
 import json
+import argparse
 
 
 class DARParser:
@@ -89,12 +90,31 @@ class DARParser:
         print(f"Number of Request Entries: {len(self.get_request_entries())}")
 
 
-if __name__ == "__main__":
-    # Example usage
-    file_path = input("Enter the path to your DAR file: ")
-    try:
-        parser = DARParser(file_path)
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description="Parse a DAR file and display information"
+    )
+    arg_parser.add_argument(
+        "file",
+        help="Path to the DAR file to parse",
+    )
+    arg_parser.add_argument(
+        "--summary",
+        action="store_true",
+        help="Print a summary of the DAR file",
+    )
+
+    args = arg_parser.parse_args()
+
+    parser = DARParser(args.file)
+
+    if args.summary:
         parser.print_dar_summary()
+
+
+if __name__ == "__main__":
+    try:
+        main()
     except Exception as e:
         print(f"An error occurred: {e}")
 

--- a/tools/validators/dar_validator.py
+++ b/tools/validators/dar_validator.py
@@ -8,7 +8,7 @@ the correct format of the DAR file.
 """
 
 import json
-import sys
+import argparse
 
 
 class DARValidator:
@@ -120,15 +120,30 @@ class DARValidator:
             print("DAR file is valid and conforms to the schema.")
 
 
-if __name__ == "__main__":
-    if len(sys.argv) != 2:
-        print("Usage: python dar_validator.py <path_to_dar_file>")
-        sys.exit(1)
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description="Validate a DAR file against the schema"
+    )
+    arg_parser.add_argument(
+        "file",
+        help="Path to the DAR file to validate",
+    )
+    arg_parser.add_argument(
+        "--validate",
+        action="store_true",
+        help="Run validation and print a report",
+    )
 
-    file_path = sys.argv[1]
-    try:
-        validator = DARValidator(file_path)
+    args = arg_parser.parse_args()
+
+    validator = DARValidator(args.file)
+    if args.validate:
         validator.print_validation_report()
+
+
+if __name__ == "__main__":
+    try:
+        main()
     except Exception as e:
         print(f"An error occurred: {e}")
 


### PR DESCRIPTION
## Summary
- add argparse-powered CLI to `dar_parser.py`
- add argparse-powered CLI to `dar_validator.py`
- document new `--summary` and `--validate` flags

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684080a1a304833385a6e869032aa92a