### PR TITLE
Add publish step for docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,17 @@ jobs:
       - name: Run tests
         run: |
           python -m unittest discover -s tests
+
+  publish:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Archive docs
+        run: zip -r docs.zip docs
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: docs
+          path: docs.zip


### PR DESCRIPTION
## Summary
- extend the CI workflow to publish zipped docs as an artifact on pushes to `main`

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_684182a00db883339757a6b611a3021a