### PR TITLE
Add coverage to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,23 +2,39 @@ name: CI
 
 on:
   push:
+    branches: [main, staging]
   pull_request:
+    branches: [main, staging]
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout repo
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/setup-python@v4
         with:
           python-version: '3.x'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install coverage
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-      - name: Run tests
+      - name: Run static check
         run: |
-          python -m unittest discover -s tests
+          python -m py_compile $(git ls-files '*.py')
+      - name: Run tests with coverage
+        run: |
+          coverage run -m unittest discover -s tests
+          coverage xml
+          coverage report
+      - name: Upload coverage
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-report
+          path: coverage.xml
 
   publish:
     needs: build
@@ -26,6 +42,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Archive docs
         run: zip -r docs.zip docs
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- run CI only on `main` and `staging`
- add a basic static check
- run tests with coverage
- upload coverage artifact
- use GitHub token for checkout

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68521647dac08333a61e37f2b61105bd