### PR TITLE
Add CI workflow with Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install coverage
+      - name: Run tests
+        env:
+          PYTHONPATH: .
+        run: |
+          coverage run -m pytest
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # DAR Schema (Data Archive Request)
 
+[![CI](https://github.com/OpenBrand/DAR-Schema/actions/workflows/ci.yml/badge.svg)](https://github.com/OpenBrand/DAR-Schema/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/OpenBrand/DAR-Schema/branch/main/graph/badge.svg)](https://codecov.io/gh/OpenBrand/DAR-Schema)
+
 The **DAR Schema** (Data Archive Request) is an open-source enhancement of the standard HAR (HTTP Archive) file format. Designed to be faster, more reliable, and more comprehensive, DAR files extend the capabilities of HAR, making them ideal for web scraping, monitoring, and data collection tasks.
 
 ## **Overview**


### PR DESCRIPTION
## Summary
- add CI workflow for running tests and uploading coverage
- show CI and Codecov badges in README

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68557fb796d88333879e70a809c5e8dc